### PR TITLE
Using turf.js to do only load data in view

### DIFF
--- a/gcmt_viewer.html
+++ b/gcmt_viewer.html
@@ -8,15 +8,17 @@
       content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
 <script
-  src='https://api.tiles.mapbox.com/mapbox.js/v2.1.5/mapbox.js'>
+  src='https://api.tiles.mapbox.com/mapbox.js/v2.3.0/mapbox.js'>
 </script>
 <script
   src="http://code.jquery.com/jquery-2.1.0.min.js">
 </script>
+<script src='https://api.mapbox.com/mapbox.js/plugins/turf/v2.0.2/turf.min.js'> 
+</script>
 
 
 <link
-  href='https://api.tiles.mapbox.com/mapbox.js/v2.1.5/mapbox.css' 
+  href='https://api.tiles.mapbox.com/mapbox.js/v2.3.0/mapbox.css' 
    rel='stylesheet' />
 
 <style>
@@ -75,7 +77,7 @@
 <script>
 L.mapbox.accessToken = 'pk.eyJ1IjoiY29zc2F0b3QiLCJhIjoiVGJyMGU5cyJ9.CMKdx74guBSUyyC-L1fAoA';
 var map = L.mapbox.map('map', 'mapbox.streets-satellite', {
-    minZoom: 3,
+    minZoom: 5,
     // These options apply to the tile layer in the map.
     tileLayer: {
         // This map option disables world wrapping. by default, it is false.
@@ -91,6 +93,7 @@ L.control.attribution().addTo(map)
 
 var layers = document.getElementById('menu-ui');
 
+var gj_gcmt_url = './data/gcmt_icons.geojson'
 var gj_4minus_url = './data/gcmt_4-_icons.geojson';
 var gj_5_55_url = './data/gcmt_5-55_icons.geojson';
 var gj_55_6_url = './data/gcmt_55-6_icons.geojson';
@@ -101,6 +104,7 @@ var HTM_url = './data/HimaTibetMap.geojson';
 var ATA_url = './data/ATA.geojson';
 var PB_url = './data/plate_bounds_bird02.geojson';
 
+/*
 $.getJSON(HTM_url, function(htm_data) {
     HTM = L.mapbox.featureLayer(htm_data);
     HTM.addTo(map);
@@ -113,15 +117,55 @@ $.getJSON(ATA_url, function(htm_data) {
     ATA.addTo(map);
     ATA.setStyle({color: 'red'})
     });
+*/
 
 var PB = L.mapbox.featureLayer().loadURL(PB_url).addTo(map);
 
-addLayer( L.mapbox.featureLayer().loadURL(gj_4minus_url), 'GCMT Mw < 5', 1);
-addLayer( L.mapbox.featureLayer().loadURL(gj_5_55_url), 'GCMT Mw 5-5.5', 2);
-addLayer( L.mapbox.featureLayer().loadURL(gj_55_6_url), 'GCMT Mw 5.5-6', 3);
-addLayer( L.mapbox.featureLayer().loadURL(gj_6_7_url), 'GCMT Mw 6-7', 4);
-addLayer( L.mapbox.featureLayer().loadURL(gj_7plus_url), 'GCMT Mw > 7', 5);
+//var gcmt_u5 = addLayer( L.mapbox.featureLayer().loadURL(gj_4minus_url), 'GCMT Mw < 5', 1);
+//var gcmt_5_55 = addLayer( L.mapbox.featureLayer().loadURL(gj_5_55_url), 'GCMT Mw 5-5.5', 2);
+//var gcmt_55_6 = addLayer( L.mapbox.featureLayer().loadURL(gj_55_6_url), 'GCMT Mw 5.5-6', 3);
+//var gcmt_6_7 = addLayer( L.mapbox.featureLayer().loadURL(gj_6_7_url), 'GCMT Mw 6-7', 4);
+//var gcmt_7p = addLayer( L.mapbox.featureLayer().loadURL(gj_7plus_url), 'GCMT Mw > 7', 5);
 
+//var gcmt_u5 = L.mapbox.featureLayer().loadURL(gj_4minus_url)
+//var gcmt_5_55 = L.mapbox.featureLayer().loadURL(gj_5_55_url)
+//var gcmt_55_6 = L.mapbox.featureLayer().loadURL(gj_55_6_url)
+//var gcmt_6_7 = L.mapbox.featureLayer().loadURL(gj_6_7_url)
+//var gcmt_7p = L.mapbox.featureLayer().loadURL(gj_7plus_url)
+var gcmt_geojson = L.mapbox.featureLayer().loadURL(gj_gcmt_url)
+
+
+//var gcmt_5 = L.mapbox.featureLayer().addTo(map);
+//var 
+//var gcmt_7 = L.mapbox.featureLayer().addTo(map);
+
+
+var gcmt_events = L.mapbox.featureLayer().addTo(map)
+
+
+
+gcmt_events.on('layeradd', function(e) {
+  var marker = e.layer,
+      feature = marker.feature;
+  marker.setIcon(L.icon(feature.properties.icon));
+});
+
+//gcmt_7.on('layeradd', function(e) {
+//  var marker = e.layer,
+//      feature = marker.feature;
+//  marker.setIcon(L.icon(feature.properties.icon));
+//});
+
+// When map has loaded, add markers for initial view
+map.on('ready', function(e){
+  addMarkerSubset(map);
+});
+
+// When the user has finished panning, add markers for 
+// resulting view
+map.on('moveend', function(e) {
+  addMarkerSubset(map);
+});
 
 
 function addLayer(layer, name, zIndex) {
@@ -157,6 +201,67 @@ function addLayer(layer, name, zIndex) {
     };
 
     layers.appendChild(link);
+}
+
+// Turn current bbox into GeoJSON polygon
+function boundsToGeoJSON(map) {
+  var currentBbox = map.getBounds();
+  // bbox format 
+  var bboxGeoJSON = {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              // SW
+              [
+                currentBbox._southWest.lng,
+                currentBbox._southWest.lat
+              ],
+              // NW
+              [
+                currentBbox._southWest.lng,
+                currentBbox._northEast.lat
+              ],
+              // NE
+              [
+                currentBbox._northEast.lng,
+                currentBbox._northEast.lat
+              ],
+              // SE 
+              [
+                currentBbox._northEast.lng,
+                currentBbox._southWest.lat
+              ],
+              // back to SW
+              [
+                currentBbox._southWest.lng,
+                currentBbox._southWest.lat
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  }
+
+  return bboxGeoJSON;
+}
+
+function addMarkerSubset(map) {
+  var currentBbox = boundsToGeoJSON(map);
+
+  var gcmtInView = turf.within(gcmt_geojson.getGeoJSON(), currentBbox);
+  gcmt_events.setGeoJSON(gcmtInView);
+  //var gcmt_u5_InView = turf.within(gcmt_u5.getGeoJSON(), currentBbox);
+  //gcmt_5.setGeoJSON(gcmt_u5_InView);
+
+  //var gcmt_7p_InView = turf.within(gcmt_7p.getGeoJSON(), currentBbox);
+  //gcmt_7.setGeoJSON(gcmt_7p_InView);
 }
 
 </script>

--- a/gcmt_viewer.html
+++ b/gcmt_viewer.html
@@ -104,7 +104,6 @@ var HTM_url = './data/HimaTibetMap.geojson';
 var ATA_url = './data/ATA.geojson';
 var PB_url = './data/plate_bounds_bird02.geojson';
 
-/*
 $.getJSON(HTM_url, function(htm_data) {
     HTM = L.mapbox.featureLayer(htm_data);
     HTM.addTo(map);
@@ -117,7 +116,6 @@ $.getJSON(ATA_url, function(htm_data) {
     ATA.addTo(map);
     ATA.setStyle({color: 'red'})
     });
-*/
 
 var PB = L.mapbox.featureLayer().loadURL(PB_url).addTo(map);
 
@@ -127,21 +125,8 @@ var PB = L.mapbox.featureLayer().loadURL(PB_url).addTo(map);
 //var gcmt_6_7 = addLayer( L.mapbox.featureLayer().loadURL(gj_6_7_url), 'GCMT Mw 6-7', 4);
 //var gcmt_7p = addLayer( L.mapbox.featureLayer().loadURL(gj_7plus_url), 'GCMT Mw > 7', 5);
 
-//var gcmt_u5 = L.mapbox.featureLayer().loadURL(gj_4minus_url)
-//var gcmt_5_55 = L.mapbox.featureLayer().loadURL(gj_5_55_url)
-//var gcmt_55_6 = L.mapbox.featureLayer().loadURL(gj_55_6_url)
-//var gcmt_6_7 = L.mapbox.featureLayer().loadURL(gj_6_7_url)
-//var gcmt_7p = L.mapbox.featureLayer().loadURL(gj_7plus_url)
 var gcmt_geojson = L.mapbox.featureLayer().loadURL(gj_gcmt_url)
-
-
-//var gcmt_5 = L.mapbox.featureLayer().addTo(map);
-//var 
-//var gcmt_7 = L.mapbox.featureLayer().addTo(map);
-
-
 var gcmt_events = L.mapbox.featureLayer().addTo(map)
-
 
 
 gcmt_events.on('layeradd', function(e) {
@@ -150,11 +135,6 @@ gcmt_events.on('layeradd', function(e) {
   marker.setIcon(L.icon(feature.properties.icon));
 });
 
-//gcmt_7.on('layeradd', function(e) {
-//  var marker = e.layer,
-//      feature = marker.feature;
-//  marker.setIcon(L.icon(feature.properties.icon));
-//});
 
 // When map has loaded, add markers for initial view
 map.on('ready', function(e){
@@ -167,7 +147,7 @@ map.on('moveend', function(e) {
   addMarkerSubset(map);
 });
 
-
+// old function for making buttons
 function addLayer(layer, name, zIndex) {
     layer
         .setZIndex(zIndex)
@@ -257,11 +237,6 @@ function addMarkerSubset(map) {
 
   var gcmtInView = turf.within(gcmt_geojson.getGeoJSON(), currentBbox);
   gcmt_events.setGeoJSON(gcmtInView);
-  //var gcmt_u5_InView = turf.within(gcmt_u5.getGeoJSON(), currentBbox);
-  //gcmt_5.setGeoJSON(gcmt_u5_InView);
-
-  //var gcmt_7p_InView = turf.within(gcmt_7p.getGeoJSON(), currentBbox);
-  //gcmt_7.setGeoJSON(gcmt_7p_InView);
 }
 
 </script>


### PR DESCRIPTION
Uses [`turf.js`](https://github.com/Turfjs/turf) to only load data in view.

Also, switches to a single GeoJSON file (`gcmt_icons.geojson`) and gets rid of the buttons.
